### PR TITLE
Support TLS

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -99,9 +99,9 @@ jobs:
           ./glauth -c sample.cfg &
           sleep 5
 
-      - name: test-search-mode
+      - name: test-tls
         run: |
-          sed -i "s/host: localhost/host: $(ifconfig eth0 | awk '/inet / {print $2}')/" example/envoy-search.yaml
+          sed -i "s/host: localhost/host: $(ifconfig eth0 | awk '/inet / {print $2}')/" example/envoy-tls.yaml
           awk 'FNR==NR{a=a$0"\\n";next} /certificateAuthority: # ""/{sub(/certificateAuthority: # ""/, "certificateAuthority: \""a"\"")} 1' glauth.crt example/envoy-tls.yaml > example/envoy.yaml.tmp && mv example/envoy.yaml.tmp example/envoy-tls.yaml
           
           make test-tls

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,6 +102,6 @@ jobs:
       - name: test-tls
         run: |
           sed -i "s/host: localhost/host: $(ifconfig eth0 | awk '/inet / {print $2}')/" example/envoy-tls.yaml
-          awk 'FNR==NR{a=a$0"\\n";next} /certificateAuthority: # ""/{sub(/certificateAuthority: # ""/, "certificateAuthority: \""a"\"")} 1' glauth.crt example/envoy-tls.yaml > example/envoy.yaml.tmp && mv example/envoy.yaml.tmp example/envoy-tls.yaml
+          awk 'FNR==NR{a=a$0"\\n";next} /rootCA: # ""/{sub(/rootCA: # ""/, "rootCA: \""a"\"")} 1' glauth.crt example/envoy-tls.yaml > example/envoy.yaml.tmp && mv example/envoy.yaml.tmp example/envoy-tls.yaml
           
           make test-tls

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,10 +1,5 @@
 name: e2e
-
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: [pull_request, push]
 
 jobs:
   test-bind:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: checkout code
+      - name: checkout
         uses: actions/checkout@v3
 
       - name: Set up Go
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: checkout code
+      - name: checkout
         uses: actions/checkout@v3
 
       - name: Set up Go
@@ -70,3 +70,43 @@ jobs:
         run: |
           sed -i "s/host: localhost/host: $(ifconfig eth0 | awk '/inet / {print $2}')/" example/envoy-search.yaml
           make test-search-mode
+
+  test-tls:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - name: prepare glauth
+        run: |
+          curl -L -o glauth https://github.com/glauth/glauth/releases/download/v2.2.0-RC1/glauth-linux-amd64
+          chmod +x glauth
+          curl -L -o sample.cfg https://raw.githubusercontent.com/glauth/glauth/master/v2/sample-simple.cfg
+          sed -i "s#listen = \"0.0.0.0:3894\"#listen = \"$(ifconfig eth0 | grep 'inet ' | awk '{print $2}'):3894\"#" sample.cfg
+          sed -i 's/enabled = false/enabled = true/g' sample.cfg
+          
+          sed -i "s/IP:127\.0\.0\.1/IP:$(hostname -I | awk '{print $1}')/g" example/tls/csr.conf
+          openssl genpkey -algorithm RSA -out glauth.key -pkeyopt rsa_keygen_bits:2048
+          openssl req -new -key glauth.key -out glauth.csr -config example/tls/csr.conf
+          openssl x509 -req -in glauth.csr -signkey glauth.key -out glauth.crt -extensions req_ext -extfile example/tls/csr.conf -days 365
+
+      - name: build
+        run: make build
+
+      - name: run glauth
+        run: |
+          ./glauth -c sample.cfg &
+          sleep 5
+
+      - name: test-search-mode
+        run: |
+          sed -i "s/host: localhost/host: $(ifconfig eth0 | awk '/inet / {print $2}')/" example/envoy-search.yaml
+          awk 'FNR==NR{a=a$0"\\n";next} /certificateAuthority: # ""/{sub(/certificateAuthority: # ""/, "certificateAuthority: \""a"\"")} 1' glauth.crt example/envoy-tls.yaml > example/envoy.yaml.tmp && mv example/envoy.yaml.tmp example/envoy-tls.yaml
+          
+          make test-tls

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test-bind-mode test-search-mode clean
+.PHONY: build run test-bind-mode test-search-mode test-tls clean
 
 build:
 	docker run --rm -v $(PWD):/go/src/go-filter -w /go/src/go-filter \
@@ -41,6 +41,20 @@ test-search-mode:
 		envoy -c /etc/envoy/envoy.yaml &
 	sleep 5
 	go test test/e2e_search_test.go
+
+	docker rm -f envoy-ldap-test
+
+test-tls:
+	docker rm -f envoy-ldap-test
+	docker run --rm -v $(PWD)/example/envoy-tls.yaml:/etc/envoy/envoy.yaml \
+		-v $(PWD)/libgolang.so:/etc/envoy/libgolang.so \
+		-e "GODEBUG=cgocheck=0" \
+		-p 10000:10000 \
+		--name envoy-ldap-test \
+		envoyproxy/envoy:contrib-v1.26.1 \
+		envoy -c /etc/envoy/envoy.yaml &
+	sleep 5
+	go test test/e2e_bind_test.go
 
 	docker rm -f envoy-ldap-test
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ http_filters:
           tls: # false
           startTLS: # false
           insecureSkipVerify: # false
-          certificateAuthority: # ""
+          rootCA: # ""
 ```
 
 Then, you can start your filter.
@@ -112,7 +112,7 @@ http_filters:
           tls: # false
           startTLS: # false
           insecureSkipVerify: # false
-          certificateAuthority: # "
+          rootCA: # "
 ```
 
 Replace the host of the LDAP server with your ip address.
@@ -183,8 +183,12 @@ Set to true if LDAP server should use an encrypted TLS connection, either with S
 
 - startTLS, bool, default false
 
-If set to true, instructs this filter to issue a StartTLS request when initializing the connection with the LDAP server. If the startTLS setting is enabled, it is important to ensure that the tls setting is also enabled.
+If set to true, instructs this filter to issue a StartTLS request(sends the command to start a TLS session and then creates a new TLS Client) when initializing the connection with the LDAP server. If the startTLS setting is enabled, it is important to ensure that the tls setting is also enabled.
 
 - insecureSkipVerify, bool, default false
 
 When TLS is enabled, the connection to the LDAP server is verified to be secure. This option allows the filter to proceed and operate even for server connections otherwise considered insecure.
+
+- rootCA, string, default ""
+
+The rootCA option should contain one or more PEM-encoded certificates to use to establish a connection with the LDAP server if the connection uses TLS but that the certificate was signed by a custom Certificate Authority.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ http_filters:
           # if the filter is set, the filter application will run in search mode.
           filter: # (&(objectClass=inetOrgPerson)(gidNumber=500)(uid=%s))
           timeout: 60 # unit is second.
+          tls: # false
+          startTLS: # false
+          insecureSkipVerify: # false
+          certificateAuthority: # ""
 ```
 
 Then, you can start your filter.
@@ -93,18 +97,22 @@ http_filters:
       plugin_config:
         "@type": type.googleapis.com/xds.type.v3.TypedStruct
         value:
-        # required
-        host: localhost
-        port: 3893
-        baseDn: dc=glauth,dc=com
-        attribute: cn
-        # optional
-        # be used in search mode
-        bindDn: # cn=admin,dc=example,dc=com
-        bindPassword: # mypassword
-        # if the filter is set, the filter application will run in search mode.
-        filter: # (&(objectClass=inetOrgPerson)(gidNumber=500)(uid=%s))
-        timeout: 60 # unit is second.
+          # required
+          host: localhost
+          port: 3893
+          baseDn: dc=glauth,dc=com
+          attribute: cn
+          # optional
+          # be used in search mode
+          bindDn: # cn=admin,dc=example,dc=com
+          bindPassword: # mypassword
+          # if the filter is set, the filter application will run in search mode.
+          filter: # (&(objectClass=inetOrgPerson)(gidNumber=500)(uid=%s))
+          timeout: 60 # unit is second.
+          tls: # false
+          startTLS: # false
+          insecureSkipVerify: # false
+          certificateAuthority: # "
 ```
 
 Replace the host of the LDAP server with your ip address.
@@ -168,3 +176,15 @@ The password corresponding to the `bindDN` specified when running in search mode
 - timeout, number, default 60
 
 An optional timeout in seconds when waiting for connection with LDAP server.
+
+- tls, bool, default false
+
+Set to true if LDAP server should use an encrypted TLS connection, either with StartTLS or regular TLS.
+
+- startTLS, bool, default false
+
+If set to true, instructs this filter to issue a StartTLS request when initializing the connection with the LDAP server. If the startTLS setting is enabled, it is important to ensure that the tls setting is also enabled.
+
+- insecureSkipVerify, bool, default false
+
+When TLS is enabled, the connection to the LDAP server is verified to be secure. This option allows the filter to proceed and operate even for server connections otherwise considered insecure.

--- a/config.go
+++ b/config.go
@@ -30,18 +30,18 @@ func init() {
 }
 
 type config struct {
-	host                 string
-	port                 uint64
-	baseDN               string
-	attribute            string
-	bindDN               string
-	password             string
-	filter               string
-	timeout              int32
-	tls                  bool
-	startTLS             bool
-	insecureSkipVerify   bool
-	certificateAuthority string
+	host               string
+	port               uint64
+	baseDN             string
+	attribute          string
+	bindDN             string
+	password           string
+	filter             string
+	timeout            int32
+	tls                bool
+	startTLS           bool
+	insecureSkipVerify bool
+	rootCA             string
 }
 
 type parser struct {
@@ -92,8 +92,8 @@ func (p *parser) Parse(any *anypb.Any) (interface{}, error) {
 	if insecureSkipVerify, ok := m["insecureSkipVerify"].(bool); ok {
 		conf.insecureSkipVerify = insecureSkipVerify
 	}
-	if certificateAuthority, ok := m["certificateAuthority"].(string); ok {
-		conf.certificateAuthority = certificateAuthority
+	if rootCA, ok := m["rootCA"].(string); ok {
+		conf.rootCA = rootCA
 	}
 	return conf, nil
 }
@@ -136,8 +136,8 @@ func (p *parser) Merge(parent interface{}, child interface{}) interface{} {
 	if childConfig.insecureSkipVerify {
 		newConfig.insecureSkipVerify = childConfig.insecureSkipVerify
 	}
-	if childConfig.certificateAuthority != "" {
-		newConfig.certificateAuthority = childConfig.certificateAuthority
+	if childConfig.rootCA != "" {
+		newConfig.rootCA = childConfig.rootCA
 	}
 	return &newConfig
 }

--- a/config.go
+++ b/config.go
@@ -30,14 +30,18 @@ func init() {
 }
 
 type config struct {
-	host      string
-	port      uint64
-	baseDN    string
-	attribute string
-	bindDN    string
-	password  string
-	filter    string
-	timeout   int32
+	host                 string
+	port                 uint64
+	baseDN               string
+	attribute            string
+	bindDN               string
+	password             string
+	filter               string
+	timeout              int32
+	tls                  bool
+	startTLS             bool
+	insecureSkipVerify   bool
+	certificateAuthority string
 }
 
 type parser struct {
@@ -73,12 +77,23 @@ func (p *parser) Parse(any *anypb.Any) (interface{}, error) {
 	if cFilter, ok := m["filter"].(string); ok {
 		conf.filter = cFilter
 	}
-
 	if timeout, ok := m["timeout"].(float64); ok {
 		conf.timeout = int32(timeout)
 	}
 	if conf.timeout == 0 {
 		conf.timeout = 60
+	}
+	if tls, ok := m["tls"].(bool); ok {
+		conf.tls = tls
+	}
+	if startTLS, ok := m["startTls"].(bool); ok {
+		conf.startTLS = startTLS
+	}
+	if insecureSkipVerify, ok := m["insecureSkipVerify"].(bool); ok {
+		conf.insecureSkipVerify = insecureSkipVerify
+	}
+	if certificateAuthority, ok := m["certificateAuthority"].(string); ok {
+		conf.certificateAuthority = certificateAuthority
 	}
 	return conf, nil
 }
@@ -111,6 +126,18 @@ func (p *parser) Merge(parent interface{}, child interface{}) interface{} {
 	}
 	if childConfig.timeout != 0 {
 		newConfig.timeout = childConfig.timeout
+	}
+	if childConfig.tls {
+		newConfig.tls = childConfig.tls
+	}
+	if childConfig.startTLS {
+		newConfig.startTLS = childConfig.startTLS
+	}
+	if childConfig.insecureSkipVerify {
+		newConfig.insecureSkipVerify = childConfig.insecureSkipVerify
+	}
+	if childConfig.certificateAuthority != "" {
+		newConfig.certificateAuthority = childConfig.certificateAuthority
 	}
 	return &newConfig
 }

--- a/example/envoy-search.yaml
+++ b/example/envoy-search.yaml
@@ -41,7 +41,7 @@ static_resources:
                           tls: # false
                           startTLS: # false
                           insecureSkipVerify: # false
-                          certificateAuthority: # ""
+                          rootCA: # ""
 
                   - name: envoy.filters.http.router
                     typed_config:

--- a/example/envoy-tls.yaml
+++ b/example/envoy-tls.yaml
@@ -41,7 +41,7 @@ static_resources:
                           tls: true # false
                           startTLS: # false
                           insecureSkipVerify: false # false
-                          certificateAuthority: # ""
+                          rootCA: # ""
 
                   - name: envoy.filters.http.router
                     typed_config:

--- a/example/envoy-tls.yaml
+++ b/example/envoy-tls.yaml
@@ -28,19 +28,19 @@ static_resources:
                         value:
                           # required
                           host: localhost
-                          port: 3893
+                          port: 3894
                           baseDn: dc=glauth,dc=com
                           attribute: cn
                           # optional
                           # be used in search mode
-                          bindDn: cn=serviceuser,ou=svcaccts,dc=glauth,dc=com
-                          bindPassword: mysecret
+                          bindDn: # cn=admin,dc=example,dc=com
+                          bindPassword: # mypassword
                           # if the filter is set, the filter application will run in search mode.
-                          filter: (cn=%s)
+                          filter: # (&(objectClass=inetOrgPerson)(gidNumber=500)(uid=%s))
                           timeout: 60 # unit is second.
-                          tls: # false
+                          tls: true # false
                           startTLS: # false
-                          insecureSkipVerify: # false
+                          insecureSkipVerify: false # false
                           certificateAuthority: # ""
 
                   - name: envoy.filters.http.router

--- a/example/envoy.yaml
+++ b/example/envoy.yaml
@@ -38,6 +38,10 @@ static_resources:
                           # if the filter is set, the filter application will run in search mode.
                           filter: # (&(objectClass=inetOrgPerson)(gidNumber=500)(uid=%s))
                           timeout: 60 # unit is second.
+                          tls: # false
+                          startTLS: # false
+                          insecureSkipVerify: # false
+                          certificateAuthority: # ""
 
                   - name: envoy.filters.http.router
                     typed_config:

--- a/example/envoy.yaml
+++ b/example/envoy.yaml
@@ -41,7 +41,7 @@ static_resources:
                           tls: # false
                           startTLS: # false
                           insecureSkipVerify: # false
-                          certificateAuthority: # ""
+                          rootCA: # ""
 
                   - name: envoy.filters.http.router
                     typed_config:

--- a/example/tls/csr.conf
+++ b/example/tls/csr.conf
@@ -1,0 +1,13 @@
+[req]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+
+distinguished_name = dn
+
+[dn]
+CN = example.com
+
+[req_ext]
+subjectAltName = IP:127.0.0.1

--- a/filter.go
+++ b/filter.go
@@ -54,11 +54,11 @@ func parseUsernameAndPassword(auth string) (username, password string, ok bool) 
 }
 
 func Connect(conf *config) (*ldap.Conn, error) {
-	var certPool *x509.CertPool
+	var rootCA *x509.CertPool
 
-	if conf.certificateAuthority != "" {
-		certPool = x509.NewCertPool()
-		certPool.AppendCertsFromPEM([]byte(conf.certificateAuthority))
+	if conf.rootCA != "" {
+		rootCA = x509.NewCertPool()
+		rootCA.AppendCertsFromPEM([]byte(conf.rootCA))
 	}
 
 	var conn *ldap.Conn = nil
@@ -67,7 +67,7 @@ func Connect(conf *config) (*ldap.Conn, error) {
 		tlsCfg := &tls.Config{
 			InsecureSkipVerify: conf.insecureSkipVerify,
 			ServerName:         conf.host,
-			RootCAs:            certPool,
+			RootCAs:            rootCA,
 		}
 		if conf.startTLS {
 			conn, err = dial(conf)


### PR DESCRIPTION
Relate issues #6.

## what my pull request does

The following options have been added to support LDAP TLS connection:

- tls, boolean, default false:

Set this option to true if the LDAP server should utilize an encrypted TLS connection, either with StartTLS or regular TLS.

- startTLS, boolean, default false:

When this option is set to true, it instructs the filter to issue a StartTLS request during the initialization of the connection with the LDAP server. If the startTLS setting is enabled, it is crucial to ensure that the tls setting is also enabled.

- insecureSkipVerify, boolean, default false:

When TLS is enabled, the connection to the LDAP server is typically verified for security. However, this option allows the filter to proceed and operate even for server connections that may otherwise be considered insecure.

- certificateAuthority, string, default "":

The certificateAuthority option should contain one or more PEM-encoded certificates to use to establish a connection with the LDAP server if the connection uses TLS but that the certificate was signed by a custom Certificate Authority.
